### PR TITLE
Add variant_preprocessing module

### DIFF
--- a/varscore/variant_preprocessing.py
+++ b/varscore/variant_preprocessing.py
@@ -1,43 +1,44 @@
 """This module handles variant preprocessing functional flows.
 
-It takes in a variants TSV file and returns coding and non-coding
-variant DataFrames.
+It takes in a variants TSV file and a genome FASTA file and creates valid, invalid, coding, and non-coding
+variant TSV files.
 """
 
+import argparse
 from varscore.variant_region_filter import filter_variants_by_region
 from varscore.validate_variants import validate_variants
-
-import pandas as pd
-from typing import Tuple
 
 from varscore.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
 
 
-def preprocess_variants(variant_tsv: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-    """Preprocess a variants DataFrame through validation and region filtering.
+def preprocess_variants(
+    variants_loc: str,
+    genome_loc: str,
+    valid_out_path: str,
+    invalid_out_path: str,
+    coding_out_path: str,
+    noncoding_out_path: str,
+) -> None:
+    """Preprocess variants through validation and region filtering.
 
     Args:
-        variant_tsv: DataFrame of variants to preprocess.
-
-    Returns:
-        Tuple of (valid_variants_df, invalid_variants_df, coding_df, noncoding_df).
-        coding_df and noncoding_df are empty DataFrames when there are no valid variants.
-
-    Raises:
-        ValueError: If variant_tsv is not a DataFrame.
-        RuntimeError: If validation or region filtering fails unexpectedly.
+        variants_loc: Path to input variants TSV file.
+        genome_loc: Path to genome FASTA file.
+        valid_out_path: Output path for valid variants.
+        invalid_out_path: Output path for invalid variants.
+        coding_out_path: Output path for coding (exonic) variants.
+        noncoding_out_path: Output path for non-coding variants.
     """
-    if not isinstance(variant_tsv, pd.DataFrame):
-        raise ValueError(f"Expected a pandas DataFrame, got {type(variant_tsv).__name__}.")
+    logger.info("Starting variant preprocessing.")
 
-    logger.info("Starting variant preprocessing on %d rows.", len(variant_tsv))
-
-    try:
-        valid_df, invalid_df = validate_variants(variant_tsv)
-    except Exception as e:
-        raise RuntimeError(f"Variant validation failed: {e}") from e
+    valid_df, invalid_df = validate_variants(
+        variants_loc,
+        genome_loc,
+        valid_out_path,
+        invalid_out_path,
+    )
 
     logger.info(
         "Validation complete: %d valid, %d invalid variants.",
@@ -45,16 +46,13 @@ def preprocess_variants(variant_tsv: pd.DataFrame) -> Tuple[pd.DataFrame, pd.Dat
         len(invalid_df),
     )
 
-    coding_df = pd.DataFrame()
-    noncoding_df = pd.DataFrame()
-
     if not valid_df.empty:
         logger.info("Filtering %d valid variants by region.", len(valid_df))
-        try:
-            coding_df, noncoding_df = filter_variants_by_region(valid_df)
-        except Exception as e:
-            raise RuntimeError(f"Region filtering failed: {e}") from e
-
+        coding_df, noncoding_df = filter_variants_by_region(
+            valid_out_path,
+            coding_out_path,
+            noncoding_out_path,
+        )
         logger.info(
             "Region filtering complete: %d coding, %d non-coding variants.",
             len(coding_df),
@@ -63,4 +61,49 @@ def preprocess_variants(variant_tsv: pd.DataFrame) -> Tuple[pd.DataFrame, pd.Dat
     else:
         logger.warning("No valid variants to filter by region.")
 
-    return valid_df, invalid_df, coding_df, noncoding_df
+
+def main():
+    args = _parse_args()
+    preprocess_variants(
+        args.input,
+        args.genome,
+        args.valid_out,
+        args.invalid_out,
+        args.coding_out,
+        args.noncoding_out,
+    )
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description="Preprocess variants through validation and region filtering."
+    )
+    parser.add_argument(
+        "-i", "--input", required=True,
+        help="Input variants TSV file (chr, pos, ref, alt columns).",
+    )
+    parser.add_argument(
+        "-g", "--genome", required=True,
+        help="Genome FASTA file for validation.",
+    )
+    parser.add_argument(
+        "-o", "--valid-out", dest="valid_out", required=True,
+        help="Output path for valid variants.",
+    )
+    parser.add_argument(
+        "--invalid-out", dest="invalid_out", required=True,
+        help="Output path for invalid variants.",
+    )
+    parser.add_argument(
+        "--coding-out", dest="coding_out", required=True,
+        help="Output path for coding (exonic) variants.",
+    )
+    parser.add_argument(
+        "--noncoding-out", dest="noncoding_out", required=True,
+        help="Output path for non-coding variants.",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()

--- a/varscore/variant_preprocessing.py
+++ b/varscore/variant_preprocessing.py
@@ -1,0 +1,66 @@
+"""This module handles variant preprocessing functional flows.
+
+It takes in a variants TSV file and returns coding and non-coding
+variant DataFrames.
+"""
+
+from varscore.variant_region_filter import filter_variants_by_region
+from varscore.validate_variants import validate_variants
+
+import pandas as pd
+from typing import Tuple
+
+from varscore.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def preprocess_variants(variant_tsv: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Preprocess a variants DataFrame through validation and region filtering.
+
+    Args:
+        variant_tsv: DataFrame of variants to preprocess.
+
+    Returns:
+        Tuple of (valid_variants_df, invalid_variants_df, coding_df, noncoding_df).
+        coding_df and noncoding_df are empty DataFrames when there are no valid variants.
+
+    Raises:
+        ValueError: If variant_tsv is not a DataFrame.
+        RuntimeError: If validation or region filtering fails unexpectedly.
+    """
+    if not isinstance(variant_tsv, pd.DataFrame):
+        raise ValueError(f"Expected a pandas DataFrame, got {type(variant_tsv).__name__}.")
+
+    logger.info("Starting variant preprocessing on %d rows.", len(variant_tsv))
+
+    try:
+        valid_df, invalid_df = validate_variants(variant_tsv)
+    except Exception as e:
+        raise RuntimeError(f"Variant validation failed: {e}") from e
+
+    logger.info(
+        "Validation complete: %d valid, %d invalid variants.",
+        len(valid_df),
+        len(invalid_df),
+    )
+
+    coding_df = pd.DataFrame()
+    noncoding_df = pd.DataFrame()
+
+    if not valid_df.empty:
+        logger.info("Filtering %d valid variants by region.", len(valid_df))
+        try:
+            coding_df, noncoding_df = filter_variants_by_region(valid_df)
+        except Exception as e:
+            raise RuntimeError(f"Region filtering failed: {e}") from e
+
+        logger.info(
+            "Region filtering complete: %d coding, %d non-coding variants.",
+            len(coding_df),
+            len(noncoding_df),
+        )
+    else:
+        logger.warning("No valid variants to filter by region.")
+
+    return valid_df, invalid_df, coding_df, noncoding_df


### PR DESCRIPTION
Added a new module that composes the variant validation and region filtering steps into a single, unified preprocessing pipeline.

- preprocess_variants(variant_tsv) accepts a raw variants DataFrame and runs it through two sequential stages:

1. Validation (validate_variants) — splits variants into valid_df and invalid_df
2. Region filtering (filter_variants_by_region) — splits valid variants into coding_df (exonic) and noncoding_df (promoter + intronic); skipped entirely if there are no valid variants
3. Returns a 4-tuple: (valid_df, invalid_df, coding_df, noncoding_df)

- Raises ValueError on bad input type and RuntimeError (with cause chained) if either stage fails unexpectedly

- Logs progress and counts at each stage via the shared logging config