### PR TITLE
Add AlphaMissense variant scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ uv run python -m varscore.scripts.construct_variants_df
 ```
 
 
+## Documentation
+
+- [AlphaMissense](docs/alphamissense.md) — setup and variant scoring
+
+
 ## Building Docker
 
 Build:

--- a/docs/alphamissense.md
+++ b/docs/alphamissense.md
@@ -1,0 +1,61 @@
+# AlphaMissense
+
+[AlphaMissense](https://www.science.org/doi/10.1126/science.adg7492) provides
+precomputed missense pathogenicity scores from DeepMind. varscore stores them as
+a chr-partitioned Parquet dataset for fast local lookups via DuckDB, and exposes
+a scoring entrypoint to annotate variant files.
+
+## Setup
+
+1. Download the AlphaMissense hg38 score file (~640MB) from the public GCS bucket:
+```bash
+./varscore/scripts/download_alphamissense.sh
+```
+
+2. Rewrite it into a chr-partitioned Parquet dataset (default output:
+   `varscore/data/alphamissense/CHROM=chr*/`):
+```bash
+uv run python -m varscore.scripts.construct_alphamissense_parquet
+```
+
+The dataset is Hive-partitioned on chromosome and sorted by position within each
+partition, so a lookup only scans the partitions for the chromosomes it needs.
+
+To write the dataset somewhere else, pass `-o/--out_path`. Whatever location you
+use here is the same one you point scoring at with `-d/--alphamissense_dir` (see
+below):
+```bash
+uv run python -m varscore.scripts.construct_alphamissense_parquet -o /data/alphamissense
+```
+
+## Scoring variants
+
+Annotate a TSV of variants (no header; columns `chr, pos, ref, alt[, variant_id]`)
+with AlphaMissense scores:
+
+```bash
+uv run python -m varscore.alphamissense_scoring -v variants.tsv -o alphamissense_scores.tsv
+```
+
+The output TSV has the original variant columns plus the AlphaMissense columns
+(`genome, uniprot_id, transcript_id, protein_variant, am_pathogenicity, am_class`)
+appended for each match.
+
+Notes:
+- Variants with no AlphaMissense entry are kept with empty score columns.
+- A variant that maps to multiple transcripts (overlapping genes) produces one
+  output row per matching transcript, so the output is not necessarily 1:1 with
+  the input.
+- Use `-d/--alphamissense_dir` to point at a non-default Parquet directory.
+
+## Python API
+
+The lookup is also available as a function for use on an in-memory DataFrame:
+
+```python
+import pandas as pd
+from varscore.utils.alphamissense_utils import lookup_alphamissense
+
+variants = pd.DataFrame({"chr": ["chr1"], "pos": [69094], "ref": ["G"], "alt": ["T"]})
+scored = lookup_alphamissense(variants)
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ version = "0.0.1a"
 requires-python = ">= 3.8, < 3.10"
 dependencies = [
 	"deeplift==0.6.13.0",
+	"duckdb>=1.0.0",
 	"fastapi>=0.103.2",
 	"intervaltree>=3.1.0",
 	"numpy==1.23.4",

--- a/tests/test_alphamissense_utils.py
+++ b/tests/test_alphamissense_utils.py
@@ -1,0 +1,114 @@
+import duckdb
+import pandas as pd
+import pytest
+
+from varscore.utils.alphamissense_utils import AM_COLUMNS, lookup_alphamissense
+
+
+def _build_dataset(tmp_path):
+    """Write a tiny chr-partitioned AlphaMissense Parquet dataset for testing.
+
+    chr1:200 G>C maps to three transcripts (a multi-transcript variant).
+    """
+    df = pd.DataFrame(
+        {
+            "CHROM": ["chr1", "chr1", "chr1", "chr1", "chr2"],
+            "POS": [100, 200, 200, 200, 300],
+            "REF": ["A", "G", "G", "G", "C"],
+            "ALT": ["T", "C", "C", "C", "T"],
+            "genome": ["hg38"] * 5,
+            "uniprot_id": ["U1", "U2a", "U2b", "U2c", "U3"],
+            "transcript_id": ["T1", "T2a", "T2b", "T2c", "T3"],
+            "protein_variant": ["p1", "p2", "p2", "p2", "p3"],
+            "am_pathogenicity": [0.1, 0.2, 0.2, 0.2, 0.9],
+            "am_class": ["likely_benign"] * 4 + ["likely_pathogenic"],
+        }
+    )
+    out_dir = tmp_path / "alphamissense"
+    con = duckdb.connect()
+    con.register("t", df)
+    con.execute(
+        f"COPY t TO '{out_dir}' (FORMAT PARQUET, PARTITION_BY (CHROM), OVERWRITE_OR_IGNORE)"
+    )
+    con.close()
+    return str(out_dir)
+
+
+def test_single_match(tmp_path):
+    am_dir = _build_dataset(tmp_path)
+    variants = pd.DataFrame(
+        {"chr": ["chr1"], "pos": [100], "ref": ["A"], "alt": ["T"]}
+    )
+    result = lookup_alphamissense(variants, am_dir)
+
+    assert len(result) == 1
+    assert result.iloc[0]["am_pathogenicity"] == 0.1
+    assert result.iloc[0]["am_class"] == "likely_benign"
+    assert result.iloc[0]["transcript_id"] == "T1"
+    # All AlphaMissense columns appended after the input columns.
+    assert list(result.columns) == ["chr", "pos", "ref", "alt"] + AM_COLUMNS
+
+
+def test_multi_transcript_expands_rows(tmp_path):
+    am_dir = _build_dataset(tmp_path)
+    variants = pd.DataFrame(
+        {"chr": ["chr1"], "pos": [200], "ref": ["G"], "alt": ["C"]}
+    )
+    result = lookup_alphamissense(variants, am_dir)
+
+    assert len(result) == 3
+    assert set(result["transcript_id"]) == {"T2a", "T2b", "T2c"}
+    assert (result["am_pathogenicity"] == 0.2).all()
+
+
+def test_no_match_is_preserved_with_nulls(tmp_path):
+    am_dir = _build_dataset(tmp_path)
+    variants = pd.DataFrame(
+        {"chr": ["chr1"], "pos": [999], "ref": ["A"], "alt": ["A"]}
+    )
+    result = lookup_alphamissense(variants, am_dir)
+
+    assert len(result) == 1
+    assert pd.isna(result.iloc[0]["am_pathogenicity"])
+    assert pd.isna(result.iloc[0]["am_class"])
+
+
+def test_chr_prefix_normalization(tmp_path):
+    am_dir = _build_dataset(tmp_path)
+    # Input chromosome without the 'chr' prefix should still match.
+    variants = pd.DataFrame({"chr": ["1"], "pos": [100], "ref": ["A"], "alt": ["T"]})
+    result = lookup_alphamissense(variants, am_dir)
+
+    assert len(result) == 1
+    assert result.iloc[0]["am_pathogenicity"] == 0.1
+    # Original input chr value is preserved (not rewritten to 'chr1').
+    assert result.iloc[0]["chr"] == "1"
+
+
+def test_input_order_and_extra_columns_preserved(tmp_path):
+    am_dir = _build_dataset(tmp_path)
+    variants = pd.DataFrame(
+        {
+            "chr": ["chr2", "chr1", "chr1"],
+            "pos": [300, 999, 100],
+            "ref": ["C", "A", "A"],
+            "alt": ["T", "A", "T"],
+            "variant_id": ["v_chr2", "v_nomatch", "v_chr1"],
+        }
+    )
+    result = lookup_alphamissense(variants, am_dir)
+
+    # 1 (chr2) + 1 (no match) + 1 (chr1) = 3 rows, in input order.
+    assert list(result["variant_id"]) == ["v_chr2", "v_nomatch", "v_chr1"]
+    assert "variant_id" in result.columns
+    assert result.iloc[0]["am_class"] == "likely_pathogenic"
+    assert pd.isna(result.iloc[1]["am_pathogenicity"])
+    assert result.iloc[2]["am_pathogenicity"] == 0.1
+
+
+def test_missing_dir_raises(tmp_path):
+    variants = pd.DataFrame(
+        {"chr": ["chr1"], "pos": [100], "ref": ["A"], "alt": ["T"]}
+    )
+    with pytest.raises(FileNotFoundError):
+        lookup_alphamissense(variants, str(tmp_path / "does_not_exist"))

--- a/varscore/alphamissense_scoring.py
+++ b/varscore/alphamissense_scoring.py
@@ -1,0 +1,119 @@
+import argparse
+import logging
+import os
+from datetime import datetime
+
+import pandas as pd
+
+import varscore.utils.alphamissense_utils as alphamissense_utils
+from varscore.utils.logging_config import get_logger, log_timing, setup_logging
+
+# Initialize logging if not already configured
+if not logging.getLogger().hasHandlers():
+    setup_logging(level="INFO")
+
+logger = get_logger(__name__)
+
+# Mirrors io_utils.VARIANT_SCHEMA; redefined here to keep this lightweight
+# lookup module free of the model/genome import chain pulled in by io_utils.
+VARIANT_SCHEMA = ["chr", "pos", "ref", "alt", "variant_id"]
+
+
+##################
+# CORE FUNCTIONS #
+##################
+
+
+def score_variants_alphamissense(
+    variants_loc: str,
+    out_path: str,
+    alphamissense_dir: str = alphamissense_utils.ALPHAMISSENSE_DIR,
+) -> None:
+    """Annotate variants with AlphaMissense scores.
+
+    Looks up each variant in the chr-partitioned AlphaMissense Parquet dataset
+    (via DuckDB) and writes a TSV with the original variant columns plus the
+    AlphaMissense columns appended. Variants with no AlphaMissense entry keep
+    empty score columns; a variant that maps to multiple transcripts produces
+    one output row per matching transcript.
+
+    Args:
+        variants_loc: Path to input variants TSV (no header; columns chr, pos,
+            ref, alt[, variant_id]).
+        out_path: Path to save the annotated TSV.
+        alphamissense_dir: Directory holding the Hive-partitioned Parquet dataset.
+    """
+    start_time = datetime.now()
+    logger.info("Starting AlphaMissense scoring")
+    logger.info(f"Variants file: {variants_loc}")
+    logger.info(f"AlphaMissense dir: {alphamissense_dir}")
+    logger.info(f"Output path: {out_path}")
+
+    logger.info("Loading variants...")
+    variant_df = pd.read_csv(variants_loc, sep="\t", names=VARIANT_SCHEMA)
+    total_variants = len(variant_df)
+    logger.info(f"Loaded {total_variants} variants")
+
+    logger.info("Looking up AlphaMissense scores...")
+    result_df = alphamissense_utils.lookup_alphamissense(variant_df, alphamissense_dir)
+
+    # Match statistics
+    matched_mask = result_df["am_pathogenicity"].notna()
+    n_matched_rows = int(matched_mask.sum())
+    n_matched_variants = int(
+        result_df.loc[matched_mask, ["chr", "pos", "ref", "alt"]]
+        .drop_duplicates()
+        .shape[0]
+    )
+    logger.info(
+        f"Matched {n_matched_variants}/{total_variants} variants "
+        f"({n_matched_rows} total matched rows; "
+        f"{len(result_df)} output rows)"
+    )
+
+    os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
+    result_df.to_csv(out_path, sep="\t", index=False)
+    logger.info(f"Results saved to {out_path}")
+
+    log_timing(logger, "AlphaMissense scoring", start_time)
+
+
+########
+# MAIN #
+########
+
+
+def main():
+    args = _parse_args()
+    score_variants_alphamissense(
+        args.variants_loc,
+        args.out_path,
+        args.alphamissense_dir,
+    )
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description="Annotate variants with AlphaMissense pathogenicity scores."
+    )
+    parser.add_argument(
+        "-v", "--variants_loc", required=True, help="Location of the variants file."
+    )
+    parser.add_argument(
+        "-o", "--out_path", required=True, help="Location to save the results."
+    )
+    parser.add_argument(
+        "-d", "--alphamissense_dir",
+        default=alphamissense_utils.ALPHAMISSENSE_DIR,
+        help="Directory with the chr-partitioned AlphaMissense Parquet dataset.",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()
+
+
+"""
+python -m varscore.alphamissense_scoring -v variants.tsv -o alphamissense_scores.tsv
+"""

--- a/varscore/scripts/construct_alphamissense_parquet.py
+++ b/varscore/scripts/construct_alphamissense_parquet.py
@@ -1,0 +1,100 @@
+"""Convert the AlphaMissense hg38 TSV into per-chromosome Parquet partitions.
+
+The raw file (`AlphaMissense_hg38.tsv.gz`, ~71M rows) is rewritten into a
+Hive-partitioned Parquet dataset keyed on chromosome:
+
+    varscore/data/alphamissense/CHROM=chr1/data_0.parquet
+    varscore/data/alphamissense/CHROM=chr2/data_0.parquet
+    ...
+
+This lets DuckDB prune to a single chromosome file at query time, e.g.:
+
+    SELECT am_pathogenicity, am_class
+    FROM read_parquet('varscore/data/alphamissense/**/*.parquet', hive_partitioning=true)
+    WHERE CHROM='chr1' AND POS=69094 AND REF='G' AND ALT='T';
+
+Rows are sorted by POS within each partition so DuckDB can skip row groups
+on positional lookups.
+
+Usage:
+    python -m varscore.scripts.construct_alphamissense_parquet
+    python -m varscore.scripts.construct_alphamissense_parquet \
+        -i varscore/data/raw/AlphaMissense_hg38.tsv.gz \
+        -o varscore/data/alphamissense
+"""
+
+import argparse
+from typing import Optional
+
+import duckdb
+
+# The TSV ships with 3 license/comment lines, then a header row whose first
+# column is "#CHROM". We skip the comment lines and supply explicit column
+# types so the output schema is stable (POS stays a 32-bit int).
+COLUMNS = {
+    "CHROM": "VARCHAR",
+    "POS": "INTEGER",
+    "REF": "VARCHAR",
+    "ALT": "VARCHAR",
+    "genome": "VARCHAR",
+    "uniprot_id": "VARCHAR",
+    "transcript_id": "VARCHAR",
+    "protein_variant": "VARCHAR",
+    "am_pathogenicity": "DOUBLE",
+    "am_class": "VARCHAR",
+}
+
+
+def construct(in_path: str, out_path: str, threads: Optional[int] = None) -> None:
+    con = duckdb.connect()
+    if threads:
+        con.execute(f"PRAGMA threads={threads}")
+
+    columns_sql = ", ".join(f"'{name}': '{dtype}'" for name, dtype in COLUMNS.items())
+
+    con.execute(
+        f"""
+        COPY (
+            SELECT * FROM read_csv(
+                '{in_path}',
+                delim='\t',
+                skip=3,
+                header=true,
+                columns={{{columns_sql}}}
+            )
+            ORDER BY CHROM, POS
+        ) TO '{out_path}' (
+            FORMAT PARQUET,
+            PARTITION_BY (CHROM),
+            OVERWRITE_OR_IGNORE,
+            COMPRESSION ZSTD
+        )
+        """
+    )
+    print(f"Wrote per-chromosome Parquet partitions to {out_path}/")
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description="Partition AlphaMissense hg38 TSV into per-chromosome Parquet files."
+    )
+    parser.add_argument(
+        "-i", "--in_path",
+        default="varscore/data/raw/AlphaMissense_hg38.tsv.gz",
+        help="Path to AlphaMissense_hg38.tsv.gz",
+    )
+    parser.add_argument(
+        "-o", "--out_path",
+        default="varscore/data/alphamissense",
+        help="Output directory for the Hive-partitioned Parquet dataset",
+    )
+    parser.add_argument(
+        "-t", "--threads", type=int, default=None,
+        help="DuckDB thread count (default: DuckDB's automatic choice)",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    construct(args.in_path, args.out_path, args.threads)

--- a/varscore/scripts/download_alphamissense.sh
+++ b/varscore/scripts/download_alphamissense.sh
@@ -1,0 +1,4 @@
+mkdir -p varscore/data/raw
+# AlphaMissense hg38 precomputed pathogenicity scores (DeepMind, CC BY-NC-SA 4.0)
+# Public GCS bucket: gs://dm_alphamissense/AlphaMissense_hg38.tsv.gz (~640MB)
+wget -O varscore/data/raw/AlphaMissense_hg38.tsv.gz https://storage.googleapis.com/dm_alphamissense/AlphaMissense_hg38.tsv.gz

--- a/varscore/utils/alphamissense_utils.py
+++ b/varscore/utils/alphamissense_utils.py
@@ -1,0 +1,98 @@
+"""AlphaMissense lookups against the chr-partitioned Parquet dataset.
+
+The dataset is produced by `varscore.scripts.construct_alphamissense_parquet`
+as a Hive-partitioned (CHROM) Parquet directory and is queried with DuckDB so
+that only the partitions for the chromosomes present in the query are scanned.
+"""
+
+import os
+
+import duckdb
+import pandas as pd
+
+from varscore.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Default location of the chr-partitioned Parquet dataset.
+ALPHAMISSENSE_DIR = "./varscore/data/alphamissense"
+
+# AlphaMissense columns brought over on a match (CHROM/POS/REF/ALT are the join
+# keys and are not duplicated into the output).
+AM_COLUMNS = [
+    "genome",
+    "uniprot_id",
+    "transcript_id",
+    "protein_variant",
+    "am_pathogenicity",
+    "am_class",
+]
+
+
+def _normalize_chr(series: pd.Series) -> pd.Series:
+    """Ensure chromosome values are prefixed with 'chr' to match the dataset."""
+    chrom = series.astype(str)
+    return chrom.where(chrom.str.startswith("chr"), "chr" + chrom)
+
+
+def lookup_alphamissense(
+    variant_df: pd.DataFrame,
+    alphamissense_dir: str = ALPHAMISSENSE_DIR,
+) -> pd.DataFrame:
+    """Left-join variants against AlphaMissense scores on (chr, pos, ref, alt).
+
+    Every input row is preserved (variants with no AlphaMissense entry get null
+    score columns). Because a genomic variant can map to multiple transcripts,
+    a variant may match more than one AlphaMissense row and thus expand to
+    multiple output rows.
+
+    Args:
+        variant_df: DataFrame with at least 'chr', 'pos', 'ref', 'alt' columns.
+        alphamissense_dir: Directory holding the Hive-partitioned Parquet dataset.
+
+    Returns:
+        The input DataFrame's columns (in order) with the AlphaMissense columns
+        in AM_COLUMNS appended.
+    """
+    if not os.path.isdir(alphamissense_dir):
+        raise FileNotFoundError(
+            f"AlphaMissense Parquet directory not found at {alphamissense_dir}. "
+            "Generate it first with: "
+            "python -m varscore.scripts.construct_alphamissense_parquet"
+        )
+
+    glob = os.path.join(alphamissense_dir, "**", "*.parquet")
+
+    # Add helper columns: normalized chr for matching and a stable row id so the
+    # output keeps the input order (and groups multi-transcript matches together).
+    query_df = variant_df.copy()
+    query_df["_chr"] = _normalize_chr(query_df["chr"])
+    query_df["_row"] = range(len(query_df))
+
+    # Restrict the Parquet scan to the chromosomes we actually need so DuckDB
+    # prunes to those partition files instead of scanning the whole genome.
+    chroms = sorted(query_df["_chr"].unique())
+    chrom_list = ", ".join(f"'{c}'" for c in chroms)
+
+    am_cols_select = ", ".join(f"am.{c}" for c in AM_COLUMNS)
+
+    con = duckdb.connect()
+    con.register("variants", query_df)
+    result = con.sql(
+        f"""
+        SELECT v.* EXCLUDE (_chr, _row), {am_cols_select}
+        FROM variants v
+        LEFT JOIN (
+            SELECT * FROM read_parquet('{glob}', hive_partitioning=true)
+            WHERE CHROM IN ({chrom_list})
+        ) am
+          ON am.CHROM = v._chr
+         AND am.POS = v.pos
+         AND am.REF = v.ref
+         AND am.ALT = v.alt
+        ORDER BY v._row
+        """
+    ).df()
+    con.close()
+
+    return result


### PR DESCRIPTION
## Summary

Adds AlphaMissense missense pathogenicity scoring to varscore: data-prep scripts, a DuckDB-backed lookup, a scoring CLI, tests, and docs.

- **Data prep** (`922c8f1`)
  - `varscore/scripts/download_alphamissense.sh` — fetches `AlphaMissense_hg38.tsv.gz` (~640MB) from the public GCS bucket.
  - `varscore/scripts/construct_alphamissense_parquet.py` — DuckDB rewrites the TSV into a chr-partitioned (Hive `CHROM=`) Parquet dataset, sorted by position within each partition for fast point lookups.

- **Scoring** (`4d243e6`)
  - `varscore/utils/alphamissense_utils.py` — `lookup_alphamissense(df, alphamissense_dir)` left-joins variants against the partitioned dataset on `(chr, pos, ref, alt)`, partition-pruned to the chromosomes present, appending all AlphaMissense columns. Unmatched variants are kept with null scores; multi-transcript variants expand to one row per match.
  - `varscore/alphamissense_scoring.py` — CLI/orchestration entrypoint mirroring the existing scoring flow.
  - Adds `duckdb` to dependencies and `tests/test_alphamissense_utils.py` (6 tests, self-contained fixtures).

- **Docs** (`afb4b4d`)
  - `docs/alphamissense.md` — setup, scoring CLI, and Python API; linked from a short Documentation section in the README.

## Configurable parquet location
The dataset location is configurable at every stage, all defaulting to `./varscore/data/alphamissense`:
- construct: `-o/--out_path`
- scoring CLI: `-d/--alphamissense_dir`
- Python API: `lookup_alphamissense(df, alphamissense_dir=...)`

## Test plan
- `python -m pytest tests/test_alphamissense_utils.py` — 6 passing (single match, multi-transcript expansion, null preservation, chr-prefix normalization, input-order/extra-column preservation, missing-dir error).
- Ran the full pipeline against the real `AlphaMissense_hg38.tsv.gz`: chr1 partition is row-for-row identical to a previously generated reference; end-to-end scoring verified on a mixed sample (match / multi-transcript / no-`chr`-prefix / no-match).

Note: the generated `varscore/data/alphamissense/` dataset is not committed (consistent with other downloaded/generated data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)