### PR TITLE
Add VCF/gVCF input support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,6 @@ jobs:
     - name: Import core API and assert it is TensorFlow-free
       run: |
         /tmp/clean/bin/python -c "import varscore; print('varscore', varscore.__version__)"
-        /tmp/clean/bin/python -c "import varscore.annotation.annotate, varscore.prioritization, varscore.preprocessing.validate, varscore.preprocessing.region_filter, varscore.preprocessing.pipeline, varscore.scoring.alphamissense.score, varscore.scoring.chrombpnet.score"
+        /tmp/clean/bin/python -c "import varscore.annotation.annotate, varscore.prioritization, varscore.preprocessing.validate, varscore.preprocessing.region_filter, varscore.preprocessing.pipeline, varscore.preprocessing.vcf, varscore.scoring.alphamissense.score, varscore.scoring.chrombpnet.score"
         /tmp/clean/bin/python -c "import varscore.annotation.regions, varscore.core.io, varscore.annotation.maf, varscore.scoring.alphamissense.lookup"
         /tmp/clean/bin/python -c "import importlib.util, sys; assert importlib.util.find_spec('tensorflow') is None, 'TensorFlow leaked into the core install'; print('core install is TensorFlow-free')"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,14 @@ contract; a model scorer like `scoring/chrombpnet/` swaps the parquet lookup for
 
 - **Variant files:** headerless TSV, columns `chr, pos, ref, alt[, variant_id]`
   (`core.io.VARIANT_SCHEMA`). Scoring outputs append columns to these.
+- **VCF/gVCF input** is accepted at the entry point via
+  `preprocessing.vcf.read_variants(path, fmt="auto")` (and the `-f/--format` flag
+  on `validate`/`pipeline`), which converts to the canonical table above —
+  everything downstream is unchanged. Pure-Python (stdlib `gzip`, **no new dep**,
+  reads `.vcf`/`.vcf.gz`); splits multi-allelic sites and drops symbolic alleles
+  (`<NON_REF>`, `<*>`, `*`, breakends). No `.bcf`. The VCF `ID` is captured into
+  `variant_id`, but full end-to-end ID preservation is still gated on the
+  `variant_id` drop in `validate.py` — see `docs/vcf.md`.
 - **Chromosome naming:** datasets use UCSC-style `chr1` / `chrM`; lookups
   normalize bare `1` / `MT` to the `chr` form. Caveat: a bare-chr value that
   slips past normalization classifies silently as `intergenic` — no error.
@@ -85,8 +93,10 @@ read `region_utils.x` / `io_utils.x` even though the modules now live under
 - `annotation/` — `annotate.py` (`AnnotatedVariant` + the annotation chain),
   `regions.py` (NCLS region classifier + nearest-gene/cCRE), `maf.py`,
   `conservation.py`.
-- `preprocessing/` — `validate.py`, `region_filter.py` (routes variants into
-  overlapping per-region category TSVs), `pipeline.py` (validate → region-filter).
+- `preprocessing/` — `vcf.py` (`read_variants`/`load_variants_vcf` — VCF/gVCF →
+  canonical table; pure-Python, no new dep), `validate.py`, `region_filter.py`
+  (routes variants into overlapping per-region category TSVs), `pipeline.py`
+  (validate → region-filter).
 - `scoring/<x>/` — one subpackage per scorer (see the scorer-module pattern):
   `alphamissense/` (`lookup.py`, `score.py`); `chrombpnet/` (`model.py`,
   `score.py`, `predictions.py`, `ingest.py`, `interpret/`) — the TF/`[model]` path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,13 +61,14 @@ contract; a model scorer like `scoring/chrombpnet/` swaps the parquet lookup for
 - **Variant files:** headerless TSV, columns `chr, pos, ref, alt[, variant_id]`
   (`core.io.VARIANT_SCHEMA`). Scoring outputs append columns to these.
 - **VCF/gVCF input** is accepted at the entry point via
-  `preprocessing.vcf.read_variants(path, fmt="auto")` (and the `-f/--format` flag
-  on `validate`/`pipeline`), which converts to the canonical table above —
-  everything downstream is unchanged. Pure-Python (stdlib `gzip`, **no new dep**,
-  reads `.vcf`/`.vcf.gz`); splits multi-allelic sites and drops symbolic alleles
-  (`<NON_REF>`, `<*>`, `*`, breakends). No `.bcf`. The VCF `ID` is captured into
-  `variant_id`, but full end-to-end ID preservation is still gated on the
-  `variant_id` drop in `validate.py` — see `docs/vcf.md`.
+  `core.io.read_variants(path, fmt="auto")` — the format-neutral loader that
+  dispatches to `load_variants` (TSV) / `load_variants_vcf` (VCF). It's wired into
+  the `-f/--format` flag on `validate`/`pipeline`, converting to the canonical
+  table above so everything downstream is unchanged. Pure-Python (stdlib `gzip`,
+  **no new dep**, reads `.vcf`/`.vcf.gz`); splits multi-allelic sites and drops
+  symbolic alleles (`<NON_REF>`, `<*>`, `*`, breakends). No `.bcf`. The VCF `ID` is
+  captured into `variant_id`, but full end-to-end ID preservation is still gated on
+  the `variant_id` drop in `validate.py` — see `docs/vcf.md`.
 - **Chromosome naming:** datasets use UCSC-style `chr1` / `chrM`; lookups
   normalize bare `1` / `MT` to the `chr` form. Caveat: a bare-chr value that
   slips past normalization classifies silently as `intergenic` — no error.
@@ -88,15 +89,17 @@ The package is grouped by function. `import` paths use aliases, so call sites
 read `region_utils.x` / `io_utils.x` even though the modules now live under
 `annotation/` / `core/`.
 
-- `core/` — `io.py` (`VARIANT_SCHEMA`, variant TSV + sequence IO), `logging.py`.
-  TF-free, depended on by everything; depends on nothing internal.
+- `core/` — `io.py` (`VARIANT_SCHEMA`; variant + sequence IO: `load_variants`
+  (TSV), `load_variants_vcf` (VCF/gVCF), the `read_variants` format dispatcher,
+  and `validate_variant`), `logging.py`. TF-free, depended on by everything;
+  depends on nothing internal.
 - `annotation/` — `annotate.py` (`AnnotatedVariant` + the annotation chain),
   `regions.py` (NCLS region classifier + nearest-gene/cCRE), `maf.py`,
   `conservation.py`.
-- `preprocessing/` — `vcf.py` (`read_variants`/`load_variants_vcf` — VCF/gVCF →
-  canonical table; pure-Python, no new dep), `validate.py`, `region_filter.py`
-  (routes variants into overlapping per-region category TSVs), `pipeline.py`
-  (validate → region-filter).
+- `preprocessing/` — `validate.py`, `region_filter.py` (routes variants into
+  overlapping per-region category TSVs), `pipeline.py` (validate → region-filter),
+  `vcf.py` (thin CLI: convert any input format → canonical TSV; loading itself
+  lives in `core.io`).
 - `scoring/<x>/` — one subpackage per scorer (see the scorer-module pattern):
   `alphamissense/` (`lookup.py`, `score.py`); `chrombpnet/` (`model.py`,
   `score.py`, `predictions.py`, `ingest.py`, `interpret/`) — the TF/`[model]` path.

--- a/docs/vcf.md
+++ b/docs/vcf.md
@@ -6,8 +6,11 @@ support is an **entry-point adapter**: the file is parsed into the canonical
 variant table, and the rest of the pipeline (validate → region filter → scorers →
 prioritization) is unchanged.
 
-The parser is pure Python and adds **no new dependency** — stdlib `gzip` reads
-both plain `.vcf` and bgzipped `.vcf.gz` (bgzip is a valid gzip stream).
+Format loading lives in the IO layer: `core.io.read_variants(path, fmt="auto")`
+is the format-neutral entry point, dispatching to the per-format adapters
+`core.io.load_variants` (TSV) and `core.io.load_variants_vcf` (VCF/gVCF). The
+parser is pure Python and adds **no new dependency** — stdlib `gzip` reads both
+plain `.vcf` and bgzipped `.vcf.gz` (bgzip is a valid gzip stream).
 
 ## Usage
 

--- a/docs/vcf.md
+++ b/docs/vcf.md
@@ -1,0 +1,63 @@
+# VCF / gVCF Input
+
+varscore accepts **VCF and gVCF** as an alternative to the canonical headerless
+variant TSV (`chr, pos, ref, alt[, variant_id]` — `core.io.VARIANT_SCHEMA`). VCF
+support is an **entry-point adapter**: the file is parsed into the canonical
+variant table, and the rest of the pipeline (validate → region filter → scorers →
+prioritization) is unchanged.
+
+The parser is pure Python and adds **no new dependency** — stdlib `gzip` reads
+both plain `.vcf` and bgzipped `.vcf.gz` (bgzip is a valid gzip stream).
+
+## Usage
+
+Standalone conversion to the canonical TSV:
+
+```bash
+python -m varscore.preprocessing.vcf -v input.vcf.gz -o variants.tsv
+```
+
+Or pass a VCF straight to validation / the full preprocessing pipeline via the
+`--format` flag (defaults to `auto`, which detects by extension):
+
+```bash
+python -m varscore.preprocessing.validate -v input.vcf.gz -g genome.fa -f auto ...
+python -m varscore.preprocessing.pipeline -i input.vcf.gz -g genome.fa -f auto \
+    -o valid.tsv --invalid-out invalid.tsv --region-out-dir regions/
+```
+
+`-f/--format` accepts `auto`, `tsv`, or `vcf`.
+
+## What the parser does
+
+- **Multi-allelic split.** A site with `ALT = A,AT` becomes one canonical row per
+  ALT allele.
+- **Symbolic / non-variant alleles dropped.** `<NON_REF>`, `<*>`, `<DEL>` (and any
+  other `<...>` form), the spanning-deletion `*`, breakend notation (`[`/`]`), and
+  monomorphic `ALT == REF` rows are filtered out — these dominate **gVCF reference
+  blocks** and would otherwise explode into millions of non-variant rows. The
+  dropped count is logged.
+- **1-based POS** is kept as-is (matches `pos`).
+- **`ID`** is carried into `variant_id`; `ID == "."` becomes missing.
+- **Chromosome naming passes through untouched.** Bare `1` → `chr1` normalization
+  and the ACGT/genome checks happen downstream in `core/io.validate_variant`, so a
+  non-ACGT or otherwise invalid allele lands in the *invalid* output with a proper
+  error reason — exactly as it would from a TSV input.
+
+## Limitations
+
+- **No binary BCF.** Convert first: `bcftools view in.bcf -Oz -o out.vcf.gz`. A
+  `.bcf` path raises a clear error.
+- **INFO / FORMAT / genotypes are ignored.** A multi-sample VCF is treated as a
+  list of sites × ALT alleles, not per-sample calls.
+- **Whole-file in memory.** Like the TSV loader, the parser returns one DataFrame;
+  `validate` then batches at 250k. Fine for typical inputs.
+
+## Custom variant IDs (future work)
+
+The VCF parser already captures the `ID` column into `variant_id`, and the
+standalone converter writes the full 5-column canonical TSV, so IDs survive the
+conversion. **End-to-end** ID preservation through the scorers is not yet wired:
+`preprocessing/validate.py` writes only `chr, pos, ref, alt` for valid variants
+(it drops `variant_id`). That single projection is the only blocker — the input
+path here is built to be extensible to it without further redesign.

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -22,6 +22,7 @@ CORE_MODULES = [
     "varscore.preprocessing.validate",
     "varscore.preprocessing.pipeline",
     "varscore.preprocessing.region_filter",
+    "varscore.preprocessing.vcf",
     "varscore.scoring.alphamissense.score",
     "varscore.scoring.chrombpnet.score",
     "varscore.annotation.regions",

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -1,0 +1,136 @@
+"""Tests for VCF/gVCF parsing (varscore.preprocessing.vcf).
+
+Fully self-contained: inline VCF strings written to tmp_path, pure text ->
+DataFrame, so no genome / parquet / monkeypatching is needed.
+"""
+import gzip
+
+import pandas as pd
+import pytest
+
+import varscore.preprocessing.vcf as vcf
+
+# A small VCF exercising the cases we care about. Tab-separated per spec.
+_HEADER = "\n".join(
+    [
+        "##fileformat=VCFv4.2",
+        "##contig=<ID=chr1>",
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO",
+    ]
+)
+
+_BODY_ROWS = [
+    "chr1\t100\trs1\tA\tT\t.\t.\t.",          # plain SNV with ID
+    "chr1\t200\t.\tC\tG,T\t.\t.\t.",          # multiallelic, missing ID
+    "chr1\t300\t.\tG\t<NON_REF>\t.\t.\t.",    # gVCF reference block -> dropped
+    "chr1\t400\t.\tA\tG,<*>\t.\t.\t.",        # one concrete + one symbolic
+    "chr1\t500\t.\tAT\tA,*\t.\t.\t.",         # indel + spanning-deletion star
+    "1\t600\trs2\tC\tG\t.\t.\t.",             # bare chr passthrough
+]
+
+SAMPLE_VCF = _HEADER + "\n" + "\n".join(_BODY_ROWS) + "\n"
+
+
+@pytest.fixture
+def vcf_path(tmp_path):
+    p = tmp_path / "sample.vcf"
+    p.write_text(SAMPLE_VCF)
+    return str(p)
+
+
+@pytest.fixture
+def vcf_gz_path(tmp_path):
+    p = tmp_path / "sample.vcf.gz"
+    with gzip.open(p, "wt") as fh:
+        fh.write(SAMPLE_VCF)
+    return str(p)
+
+
+def _row(df, chrom, pos, alt):
+    sel = df[(df["chr"] == chrom) & (df["pos"] == pos) & (df["alt"] == alt)]
+    assert len(sel) == 1, f"expected exactly one row for {chrom}:{pos} {alt}"
+    return sel.iloc[0]
+
+
+def test_columns_and_plain_snv(vcf_path):
+    df = vcf.load_variants_vcf(vcf_path)
+    assert list(df.columns) == vcf.VARIANT_SCHEMA
+    row = _row(df, "chr1", 100, "T")
+    assert row["ref"] == "A"
+    assert row["variant_id"] == "rs1"
+
+
+def test_multiallelic_split(vcf_path):
+    df = vcf.load_variants_vcf(vcf_path)
+    alts = set(df[(df["chr"] == "chr1") & (df["pos"] == 200)]["alt"])
+    assert alts == {"G", "T"}
+    # missing ID (.) -> NaN for both split rows
+    assert df[(df["pos"] == 200)]["variant_id"].isna().all()
+
+
+def test_symbolic_non_ref_dropped(vcf_path, caplog):
+    with caplog.at_level("INFO"):
+        df = vcf.load_variants_vcf(vcf_path)
+    # the <NON_REF>-only site emits nothing
+    assert df[(df["pos"] == 300)].empty
+    assert "dropped" in caplog.text.lower()
+
+
+def test_mixed_concrete_and_symbolic(vcf_path):
+    df = vcf.load_variants_vcf(vcf_path)
+    pos400 = df[(df["pos"] == 400)]
+    assert set(pos400["alt"]) == {"G"}  # <*> dropped, G survives
+
+
+def test_indel_and_spanning_deletion_star(vcf_path):
+    df = vcf.load_variants_vcf(vcf_path)
+    pos500 = df[(df["pos"] == 500)]
+    assert set(pos500["alt"]) == {"A"}  # the AT->A deletion; '*' dropped
+    assert _row(df, "chr1", 500, "A")["ref"] == "AT"
+
+
+def test_bare_chr_passthrough(vcf_path):
+    df = vcf.load_variants_vcf(vcf_path)
+    # parser does NOT normalize chr; that is validate's job downstream
+    row = _row(df, "1", 600, "G")
+    assert row["variant_id"] == "rs2"
+
+
+def test_gzip_matches_plaintext(vcf_path, vcf_gz_path):
+    plain = vcf.load_variants_vcf(vcf_path)
+    gzipped = vcf.load_variants_vcf(vcf_gz_path)
+    pd.testing.assert_frame_equal(plain, gzipped)
+
+
+def test_read_variants_dispatch_vcf(vcf_path, vcf_gz_path):
+    assert len(vcf.read_variants(vcf_path)) == len(vcf.load_variants_vcf(vcf_path))
+    assert len(vcf.read_variants(vcf_gz_path)) == len(vcf.load_variants_vcf(vcf_gz_path))
+
+
+def test_read_variants_dispatch_tsv(tmp_path):
+    # a 5-col canonical TSV should route to the headerless-TSV loader
+    p = tmp_path / "variants.tsv"
+    p.write_text("chr1\t100\tA\tT\tv1\nchr1\t200\tC\tG\tv2\n")
+    df = vcf.read_variants(str(p))
+    assert list(df.columns) == vcf.VARIANT_SCHEMA
+    assert df.iloc[0]["variant_id"] == "v1"
+
+
+def test_read_variants_bcf_rejected(tmp_path):
+    with pytest.raises(ValueError, match="BCF"):
+        vcf.read_variants(str(tmp_path / "data.bcf"))
+
+
+def test_symbolic_only_returns_empty_with_schema(tmp_path):
+    p = tmp_path / "blocks.vcf"
+    p.write_text(_HEADER + "\nchr1\t10\t.\tG\t<NON_REF>\t.\t.\t.\n")
+    df = vcf.load_variants_vcf(str(p))
+    assert df.empty
+    assert list(df.columns) == vcf.VARIANT_SCHEMA
+
+
+def test_malformed_line_raises(tmp_path):
+    p = tmp_path / "bad.vcf"
+    p.write_text(_HEADER + "\nchr1\t10\trs1\tA\n")  # only 4 fields
+    with pytest.raises(ValueError, match="malformed"):
+        vcf.load_variants_vcf(str(p))

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -1,4 +1,4 @@
-"""Tests for VCF/gVCF parsing (varscore.preprocessing.vcf).
+"""Tests for VCF/gVCF parsing and format dispatch (varscore.core.io).
 
 Fully self-contained: inline VCF strings written to tmp_path, pure text ->
 DataFrame, so no genome / parquet / monkeypatching is needed.
@@ -8,7 +8,7 @@ import gzip
 import pandas as pd
 import pytest
 
-import varscore.preprocessing.vcf as vcf
+import varscore.core.io as vcf
 
 # A small VCF exercising the cases we care about. Tab-separated per spec.
 _HEADER = "\n".join(

--- a/varscore/core/io.py
+++ b/varscore/core/io.py
@@ -1,3 +1,4 @@
+import gzip
 import re
 import numpy as np
 import pandas as pd
@@ -257,9 +258,134 @@ VARIANT_SCHEMA = ["chr", "pos", "ref", "alt", "variant_id"]
 
 
 def load_variants(variants_loc: str) -> pd.DataFrame:
-    """Load a variants DataFrame."""
+    """Load a variants DataFrame from a headerless canonical TSV."""
     variants_df = pd.read_csv(variants_loc, sep="\t", names=VARIANT_SCHEMA)
     return variants_df
+
+
+# Extensions that indicate gzip/bgzip compression.
+_GZIP_SUFFIXES = (".gz", ".bgz")
+# Extensions that indicate a VCF (after stripping any gzip suffix).
+_VCF_SUFFIXES = (".vcf", ".gvcf")
+
+
+def _is_symbolic_alt(alt: str, ref: str) -> bool:
+    """Return True if ``alt`` is not a concrete REF->ALT base substitution.
+
+    Drops the alleles that pepper gVCF reference blocks and structural-variant
+    records and that genome-aware validation could not score anyway: the symbolic
+    ``<...>`` forms (``<NON_REF>``, ``<*>``, ``<DEL>``, ...), the spanning-deletion
+    star / missing / empty allele, breakend notation, and the monomorphic
+    ``alt == ref`` no-op some gVCF tools emit. Concrete sequences (including
+    indels, and even malformed ones like lowercase/``N``) are kept and left for
+    ``validate_variant`` to vet, matching the canonical-TSV input path.
+    """
+    if alt in {"*", ".", ""}:
+        return True
+    if alt.startswith("<") and alt.endswith(">"):
+        return True
+    if "[" in alt or "]" in alt:
+        return True
+    if alt == ref:
+        return True
+    return False
+
+
+def load_variants_vcf(path: str) -> pd.DataFrame:
+    """Parse a VCF/gVCF (``.vcf`` or ``.vcf.gz``) into the canonical variant table.
+
+    Pure Python, no extra dependency: stdlib ``gzip`` streams both plain ``.vcf``
+    and bgzipped ``.vcf.gz`` (bgzip is a valid gzip stream). Multi-allelic ``ALT``
+    is split into one row per concrete allele; symbolic / non-variant alleles
+    (see ``_is_symbolic_alt``) are dropped with a logged count so gVCF reference
+    blocks don't explode into millions of non-variant rows. ``POS`` is 1-based
+    (matching ``pos``); ``ID == "."`` becomes a missing ``variant_id``. Chromosome
+    naming and ACGT/genome checks are deferred to ``validate_variant`` downstream.
+
+    Args:
+        path: Path to a plain or bgzipped VCF/gVCF file.
+
+    Returns:
+        DataFrame with columns ``chr, pos, ref, alt, variant_id`` (one row per
+        concrete ALT allele). The columns are always present, even when empty.
+    """
+    opener = gzip.open if path.endswith(_GZIP_SUFFIXES) else open
+
+    rows = []
+    n_sites = 0  # data (non-header) lines seen
+    n_symbolic = 0  # symbolic / non-variant ALT alleles dropped
+
+    with opener(path, "rt") as fh:
+        for lineno, line in enumerate(fh, start=1):
+            if line.startswith("#"):  # ## meta + #CHROM header
+                continue
+            line = line.rstrip("\n")
+            if not line:
+                continue
+
+            fields = line.split("\t")
+            if len(fields) < 5:
+                raise ValueError(
+                    f"{path}:{lineno}: malformed VCF data line, expected at least "
+                    f"5 tab-separated fields (CHROM POS ID REF ALT), got {len(fields)}"
+                )
+            chrom, pos, vid, ref, alt = fields[:5]
+            n_sites += 1
+
+            variant_id = None if vid == "." else vid
+            pos = int(pos)  # VCF POS is 1-based, matching our schema
+
+            for allele in alt.split(","):  # split multi-allelic sites
+                if _is_symbolic_alt(allele, ref):
+                    n_symbolic += 1
+                    continue
+                rows.append((chrom, pos, ref, allele, variant_id))
+
+    logger.info(
+        "Parsed %d VCF sites -> %d concrete variant rows; "
+        "dropped %d symbolic/non-variant ALT alleles",
+        n_sites,
+        len(rows),
+        n_symbolic,
+    )
+
+    return pd.DataFrame(rows, columns=VARIANT_SCHEMA)
+
+
+def read_variants(path: str, fmt: str = "auto") -> pd.DataFrame:
+    """Load variants into the canonical table, dispatching on file format.
+
+    This is the format-neutral entry point; ``load_variants`` (TSV) and
+    ``load_variants_vcf`` (VCF/gVCF) are the per-format adapters it composes.
+
+    Args:
+        path: Input variants file.
+        fmt: One of ``"auto"``, ``"tsv"``, ``"vcf"``. ``"auto"`` routes
+            ``.vcf``/``.vcf.gz`` (and ``.gvcf``) to the VCF parser and everything
+            else to ``load_variants``; ``.bcf`` raises a clear error.
+
+    Returns:
+        DataFrame with columns ``chr, pos, ref, alt, variant_id``.
+    """
+    if fmt == "vcf":
+        return load_variants_vcf(path)
+    if fmt == "tsv":
+        return load_variants(path)
+    if fmt != "auto":
+        raise ValueError(f"Unknown format {fmt!r}; expected one of auto, tsv, vcf.")
+
+    # auto-detect by extension (strip any gzip suffix first)
+    base = path
+    if base.endswith(_GZIP_SUFFIXES):
+        base = base.rsplit(".", 1)[0]
+    if base.endswith(".bcf") or path.endswith(".bcf"):
+        raise ValueError(
+            f"Binary BCF is not supported ({path}); convert to VCF first, e.g. "
+            "`bcftools view in.bcf -Oz -o out.vcf.gz`."
+        )
+    if base.endswith(_VCF_SUFFIXES):
+        return load_variants_vcf(path)
+    return load_variants(path)
 
 
 if __name__ == "__main__":

--- a/varscore/preprocessing/pipeline.py
+++ b/varscore/preprocessing/pipeline.py
@@ -21,16 +21,18 @@ def preprocess_variants(
     invalid_out_path: str,
     region_out_dir: str,
     categories=None,
+    fmt: str = "auto",
 ) -> None:
     """Preprocess variants through validation and region filtering.
 
     Args:
-        variants_loc: Path to input variants TSV file.
+        variants_loc: Path to input variants file (TSV or VCF/gVCF).
         genome_loc: Path to genome FASTA file.
         valid_out_path: Output path for valid variants.
         invalid_out_path: Output path for invalid variants.
         region_out_dir: Directory for the per-region-category variant TSVs.
         categories: Optional subset of region categories to emit (default: all).
+        fmt: Input format, one of "auto", "tsv", "vcf" (default: auto-detect).
     """
     logger.info("Starting variant preprocessing.")
 
@@ -39,6 +41,7 @@ def preprocess_variants(
         genome_loc,
         valid_out_path,
         invalid_out_path,
+        fmt=fmt,
     )
 
     logger.info(
@@ -74,6 +77,7 @@ def main():
         args.invalid_out,
         args.region_out_dir,
         categories,
+        args.format,
     )
 
 
@@ -83,7 +87,8 @@ def _parse_args():
     )
     parser.add_argument(
         "-i", "--input", required=True,
-        help="Input variants TSV file (chr, pos, ref, alt columns).",
+        help="Input variants file: canonical TSV (chr, pos, ref, alt[, variant_id]) "
+        "or VCF/gVCF (.vcf, .vcf.gz).",
     )
     parser.add_argument(
         "-g", "--genome", required=True,
@@ -104,6 +109,10 @@ def _parse_args():
     parser.add_argument(
         "--categories",
         help="Comma-separated subset of region categories to emit (default: all).",
+    )
+    parser.add_argument(
+        "-f", "--format", default="auto", choices=["auto", "tsv", "vcf"],
+        help="Input format (default: auto, detected by extension).",
     )
     return parser.parse_args()
 

--- a/varscore/preprocessing/validate.py
+++ b/varscore/preprocessing/validate.py
@@ -7,7 +7,6 @@ from typing import Tuple, List, Optional
 from datetime import datetime
 
 import varscore.core.io as io_utils
-from varscore.preprocessing.vcf import read_variants
 from varscore.core.logging import get_logger, log_timing, log_progress, setup_logging
 import logging
 
@@ -57,7 +56,7 @@ def validate_variants(
     
     # Load full variant dataframe (TSV or VCF/gVCF, dispatched by `fmt`)
     logger.info("Loading variants...")
-    variant_df = read_variants(variants_loc, fmt)
+    variant_df = io_utils.read_variants(variants_loc, fmt)
     total_variants = len(variant_df)
     logger.info(f"Loaded {total_variants} variants")
     

--- a/varscore/preprocessing/validate.py
+++ b/varscore/preprocessing/validate.py
@@ -7,6 +7,7 @@ from typing import Tuple, List, Optional
 from datetime import datetime
 
 import varscore.core.io as io_utils
+from varscore.preprocessing.vcf import read_variants
 from varscore.core.logging import get_logger, log_timing, log_progress, setup_logging
 import logging
 
@@ -30,6 +31,7 @@ def validate_variants(
     invalid_out_path: Optional[str] = None,
     width: int = 2114,
     batch_size: int = 250000,
+    fmt: str = "auto",
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """Validate variants and return valid and invalid variant dataframes.
 
@@ -40,6 +42,8 @@ def validate_variants(
         invalid_out_path: Optional path to save invalid variants. If None, only returns dataframes.
         width: Sequence width for validation (default: 2114).
         batch_size: Number of variants to process at once to manage memory.
+        fmt: Input format, one of "auto", "tsv", "vcf" (default: auto-detect by
+            extension). VCF/gVCF is converted to the canonical table on load.
 
     Returns:
         Tuple of (valid_variants_df, invalid_variants_df)
@@ -51,9 +55,9 @@ def validate_variants(
     logger.info(f"Sequence width: {width}")
     logger.info(f"Batch size: {batch_size}")
     
-    # Load full variant dataframe
+    # Load full variant dataframe (TSV or VCF/gVCF, dispatched by `fmt`)
     logger.info("Loading variants...")
-    variant_df = io_utils.load_variants(variants_loc)
+    variant_df = read_variants(variants_loc, fmt)
     total_variants = len(variant_df)
     logger.info(f"Loaded {total_variants} variants")
     
@@ -107,7 +111,10 @@ def validate_variants(
         valid_variants.append(batch_valid)
         invalid_variants.append(batch_invalid)
         
-        # Write valid variants incrementally (append mode, no headers)
+        # Write valid variants incrementally (append mode, no headers).
+        # NOTE: variant_id is intentionally dropped here for now. Preserving it
+        # end-to-end is a future goal; this projection is the single blocker to
+        # threading custom IDs through to the scorers (see docs/vcf.md).
         if valid_out_path and not batch_valid.empty:
             batch_valid[["chr", "pos", "ref", "alt"]].to_csv(
                 valid_out_path, sep="\t", index=False, header=False, mode="a"
@@ -159,6 +166,7 @@ def main():
         args.invalid_out_path,
         args.width,
         args.batch_size,
+        args.format,
     )
     
     # Print summary
@@ -200,6 +208,10 @@ def _parse_args():
     parser.add_argument(
         "-b", "--batch_size", type=int, default=250000,
         help="Number of variants to process at once (default: 250000)."
+    )
+    parser.add_argument(
+        "-f", "--format", default="auto", choices=["auto", "tsv", "vcf"],
+        help="Input format (default: auto, detected by extension)."
     )
     return parser.parse_args()
 

--- a/varscore/preprocessing/vcf.py
+++ b/varscore/preprocessing/vcf.py
@@ -1,37 +1,19 @@
-"""VCF/gVCF input adapter for the variant preprocessing entry point.
+"""CLI to convert an input variants file into the canonical headerless TSV.
 
-The whole downstream pipeline (validate -> region_filter -> scorers ->
-prioritization) consumes the canonical headerless variant table
-(``chr, pos, ref, alt[, variant_id]`` -- ``core.io.VARIANT_SCHEMA``). VCF support
-is therefore purely an *entry-point adapter*: parse VCF/gVCF into that canonical
-DataFrame and nothing downstream changes.
+The actual format loading/dispatch lives in ``core.io`` (``read_variants`` +
+the per-format adapters ``load_variants`` / ``load_variants_vcf``). This module
+is just the user-facing converter entry point:
 
-Implementation notes:
-  - Pure Python, **no new dependency**. Stdlib ``gzip`` streams both plain ``.vcf``
-    and bgzipped ``.vcf.gz`` (bgzip is a valid gzip stream; same trick as
-    ``annotation/maf.py``). Consequence: binary ``.bcf`` is not supported (convert
-    with ``bcftools view``), and there is no tabix random access -- we scan once.
-  - Multi-allelic ``ALT`` (comma-separated) is split into one canonical row per
-    concrete ALT allele.
-  - Symbolic / non-substitution alleles (``<NON_REF>``, ``<*>``, ``<DEL>``, ``*``,
-    breakends) are dropped -- these dominate gVCF reference blocks and would
-    otherwise explode into millions of non-variant rows.
-  - VCF ``POS`` is 1-based, matching ``pos``. ``ID == "."`` -> missing
-    ``variant_id``; any other ID is carried through (so the new input path is
-    *extensible* to end-to-end ID preservation -- see ``preprocessing/validate.py``
-    for the one remaining drop that gates that future work).
-  - Chromosome naming is passed through untouched; ``core/io.validate_variant``
-    normalizes bare ``1`` -> ``chr1`` and rejects non-ACGT alleles downstream, so
-    we deliberately do not duplicate that here.
+    python -m varscore.preprocessing.vcf -v input.vcf.gz -o variants.tsv
 
-See ``docs/vcf.md`` for the user-facing reference.
+VCF/gVCF input is described in ``docs/vcf.md``. Validation and the full
+preprocessing pipeline accept VCF directly via their own ``-f/--format`` flag, so
+this converter is only needed when you want the canonical TSV as a standalone
+artifact.
 """
 
 import argparse
-import gzip
 import logging
-
-import pandas as pd
 
 import varscore.core.io as io_utils
 from varscore.core.logging import get_logger, setup_logging
@@ -42,136 +24,10 @@ if not logging.getLogger().hasHandlers():
 
 logger = get_logger(__name__)
 
-# Mirrors io_utils.VARIANT_SCHEMA; redefined here to keep parsing self-contained.
-VARIANT_SCHEMA = ["chr", "pos", "ref", "alt", "variant_id"]
-
-# Extensions that indicate gzip/bgzip compression.
-_GZIP_SUFFIXES = (".gz", ".bgz")
-# Extensions that indicate a VCF (after stripping any gzip suffix).
-_VCF_SUFFIXES = (".vcf", ".gvcf")
-
-
-##################
-# CORE FUNCTIONS #
-##################
-
-
-def _is_symbolic_alt(alt: str, ref: str) -> bool:
-    """Return True if ``alt`` is not a concrete REF->ALT base substitution.
-
-    Drops the alleles that pepper gVCF reference blocks and structural-variant
-    records and that downstream genome-aware validation could not score anyway:
-    the symbolic ``<...>`` forms (``<NON_REF>``, ``<*>``, ``<DEL>``, ...), the
-    spanning-deletion star / missing / empty allele, breakend notation, and the
-    monomorphic ``alt == ref`` no-op some gVCF tools emit. Concrete sequences
-    (including indels, and even malformed ones like lowercase/``N``) are kept and
-    left for ``core/io.validate_variant`` to vet, matching the TSV input path.
-    """
-    if alt in {"*", ".", ""}:
-        return True
-    if alt.startswith("<") and alt.endswith(">"):
-        return True
-    if "[" in alt or "]" in alt:
-        return True
-    if alt == ref:
-        return True
-    return False
-
-
-def load_variants_vcf(path: str) -> pd.DataFrame:
-    """Parse a VCF/gVCF (``.vcf`` or ``.vcf.gz``) into the canonical variant table.
-
-    Args:
-        path: Path to a plain or bgzipped VCF/gVCF file.
-
-    Returns:
-        DataFrame with columns ``chr, pos, ref, alt, variant_id`` (one row per
-        concrete ALT allele). The columns are always present, even when empty.
-    """
-    opener = gzip.open if path.endswith(_GZIP_SUFFIXES) else open
-
-    rows = []
-    n_sites = 0  # data (non-header) lines seen
-    n_symbolic = 0  # symbolic / non-variant ALT alleles dropped
-
-    with opener(path, "rt") as fh:
-        for lineno, line in enumerate(fh, start=1):
-            if line.startswith("#"):  # ## meta + #CHROM header
-                continue
-            line = line.rstrip("\n")
-            if not line:
-                continue
-
-            fields = line.split("\t")
-            if len(fields) < 5:
-                raise ValueError(
-                    f"{path}:{lineno}: malformed VCF data line, expected at least "
-                    f"5 tab-separated fields (CHROM POS ID REF ALT), got {len(fields)}"
-                )
-            chrom, pos, vid, ref, alt = fields[:5]
-            n_sites += 1
-
-            variant_id = None if vid == "." else vid
-            pos = int(pos)  # VCF POS is 1-based, matching our schema
-
-            for allele in alt.split(","):  # split multi-allelic sites
-                if _is_symbolic_alt(allele, ref):
-                    n_symbolic += 1
-                    continue
-                rows.append((chrom, pos, ref, allele, variant_id))
-
-    logger.info(
-        "Parsed %d VCF sites -> %d concrete variant rows; "
-        "dropped %d symbolic/non-variant ALT alleles",
-        n_sites,
-        len(rows),
-        n_symbolic,
-    )
-
-    return pd.DataFrame(rows, columns=VARIANT_SCHEMA)
-
-
-def read_variants(path: str, fmt: str = "auto") -> pd.DataFrame:
-    """Load variants into the canonical table, dispatching on file format.
-
-    Args:
-        path: Input variants file.
-        fmt: One of ``"auto"``, ``"tsv"``, ``"vcf"``. ``"auto"`` routes
-            ``.vcf``/``.vcf.gz`` (and ``.gvcf``) to the VCF parser and everything
-            else to the headerless-TSV loader; ``.bcf`` raises a clear error.
-
-    Returns:
-        DataFrame with columns ``chr, pos, ref, alt, variant_id``.
-    """
-    if fmt == "vcf":
-        return load_variants_vcf(path)
-    if fmt == "tsv":
-        return io_utils.load_variants(path)
-    if fmt != "auto":
-        raise ValueError(f"Unknown format {fmt!r}; expected one of auto, tsv, vcf.")
-
-    # auto-detect by extension (strip any gzip suffix first)
-    base = path
-    if base.endswith(_GZIP_SUFFIXES):
-        base = base.rsplit(".", 1)[0]
-    if base.endswith(".bcf") or path.endswith(".bcf"):
-        raise ValueError(
-            f"Binary BCF is not supported ({path}); convert to VCF first, e.g. "
-            "`bcftools view in.bcf -Oz -o out.vcf.gz`."
-        )
-    if base.endswith(_VCF_SUFFIXES):
-        return load_variants_vcf(path)
-    return io_utils.load_variants(path)
-
-
-########
-# MAIN #
-########
-
 
 def main():
     args = _parse_args()
-    df = read_variants(args.variants_loc, args.format)
+    df = io_utils.read_variants(args.variants_loc, args.format)
     # Write the full 5-col canonical table (variant_id included) so the converter
     # output faithfully carries any VCF IDs forward.
     df.to_csv(args.out_path, sep="\t", index=False, header=False)

--- a/varscore/preprocessing/vcf.py
+++ b/varscore/preprocessing/vcf.py
@@ -1,0 +1,207 @@
+"""VCF/gVCF input adapter for the variant preprocessing entry point.
+
+The whole downstream pipeline (validate -> region_filter -> scorers ->
+prioritization) consumes the canonical headerless variant table
+(``chr, pos, ref, alt[, variant_id]`` -- ``core.io.VARIANT_SCHEMA``). VCF support
+is therefore purely an *entry-point adapter*: parse VCF/gVCF into that canonical
+DataFrame and nothing downstream changes.
+
+Implementation notes:
+  - Pure Python, **no new dependency**. Stdlib ``gzip`` streams both plain ``.vcf``
+    and bgzipped ``.vcf.gz`` (bgzip is a valid gzip stream; same trick as
+    ``annotation/maf.py``). Consequence: binary ``.bcf`` is not supported (convert
+    with ``bcftools view``), and there is no tabix random access -- we scan once.
+  - Multi-allelic ``ALT`` (comma-separated) is split into one canonical row per
+    concrete ALT allele.
+  - Symbolic / non-substitution alleles (``<NON_REF>``, ``<*>``, ``<DEL>``, ``*``,
+    breakends) are dropped -- these dominate gVCF reference blocks and would
+    otherwise explode into millions of non-variant rows.
+  - VCF ``POS`` is 1-based, matching ``pos``. ``ID == "."`` -> missing
+    ``variant_id``; any other ID is carried through (so the new input path is
+    *extensible* to end-to-end ID preservation -- see ``preprocessing/validate.py``
+    for the one remaining drop that gates that future work).
+  - Chromosome naming is passed through untouched; ``core/io.validate_variant``
+    normalizes bare ``1`` -> ``chr1`` and rejects non-ACGT alleles downstream, so
+    we deliberately do not duplicate that here.
+
+See ``docs/vcf.md`` for the user-facing reference.
+"""
+
+import argparse
+import gzip
+import logging
+
+import pandas as pd
+
+import varscore.core.io as io_utils
+from varscore.core.logging import get_logger, setup_logging
+
+# Initialize logging if not already configured
+if not logging.getLogger().hasHandlers():
+    setup_logging(level="INFO")
+
+logger = get_logger(__name__)
+
+# Mirrors io_utils.VARIANT_SCHEMA; redefined here to keep parsing self-contained.
+VARIANT_SCHEMA = ["chr", "pos", "ref", "alt", "variant_id"]
+
+# Extensions that indicate gzip/bgzip compression.
+_GZIP_SUFFIXES = (".gz", ".bgz")
+# Extensions that indicate a VCF (after stripping any gzip suffix).
+_VCF_SUFFIXES = (".vcf", ".gvcf")
+
+
+##################
+# CORE FUNCTIONS #
+##################
+
+
+def _is_symbolic_alt(alt: str, ref: str) -> bool:
+    """Return True if ``alt`` is not a concrete REF->ALT base substitution.
+
+    Drops the alleles that pepper gVCF reference blocks and structural-variant
+    records and that downstream genome-aware validation could not score anyway:
+    the symbolic ``<...>`` forms (``<NON_REF>``, ``<*>``, ``<DEL>``, ...), the
+    spanning-deletion star / missing / empty allele, breakend notation, and the
+    monomorphic ``alt == ref`` no-op some gVCF tools emit. Concrete sequences
+    (including indels, and even malformed ones like lowercase/``N``) are kept and
+    left for ``core/io.validate_variant`` to vet, matching the TSV input path.
+    """
+    if alt in {"*", ".", ""}:
+        return True
+    if alt.startswith("<") and alt.endswith(">"):
+        return True
+    if "[" in alt or "]" in alt:
+        return True
+    if alt == ref:
+        return True
+    return False
+
+
+def load_variants_vcf(path: str) -> pd.DataFrame:
+    """Parse a VCF/gVCF (``.vcf`` or ``.vcf.gz``) into the canonical variant table.
+
+    Args:
+        path: Path to a plain or bgzipped VCF/gVCF file.
+
+    Returns:
+        DataFrame with columns ``chr, pos, ref, alt, variant_id`` (one row per
+        concrete ALT allele). The columns are always present, even when empty.
+    """
+    opener = gzip.open if path.endswith(_GZIP_SUFFIXES) else open
+
+    rows = []
+    n_sites = 0  # data (non-header) lines seen
+    n_symbolic = 0  # symbolic / non-variant ALT alleles dropped
+
+    with opener(path, "rt") as fh:
+        for lineno, line in enumerate(fh, start=1):
+            if line.startswith("#"):  # ## meta + #CHROM header
+                continue
+            line = line.rstrip("\n")
+            if not line:
+                continue
+
+            fields = line.split("\t")
+            if len(fields) < 5:
+                raise ValueError(
+                    f"{path}:{lineno}: malformed VCF data line, expected at least "
+                    f"5 tab-separated fields (CHROM POS ID REF ALT), got {len(fields)}"
+                )
+            chrom, pos, vid, ref, alt = fields[:5]
+            n_sites += 1
+
+            variant_id = None if vid == "." else vid
+            pos = int(pos)  # VCF POS is 1-based, matching our schema
+
+            for allele in alt.split(","):  # split multi-allelic sites
+                if _is_symbolic_alt(allele, ref):
+                    n_symbolic += 1
+                    continue
+                rows.append((chrom, pos, ref, allele, variant_id))
+
+    logger.info(
+        "Parsed %d VCF sites -> %d concrete variant rows; "
+        "dropped %d symbolic/non-variant ALT alleles",
+        n_sites,
+        len(rows),
+        n_symbolic,
+    )
+
+    return pd.DataFrame(rows, columns=VARIANT_SCHEMA)
+
+
+def read_variants(path: str, fmt: str = "auto") -> pd.DataFrame:
+    """Load variants into the canonical table, dispatching on file format.
+
+    Args:
+        path: Input variants file.
+        fmt: One of ``"auto"``, ``"tsv"``, ``"vcf"``. ``"auto"`` routes
+            ``.vcf``/``.vcf.gz`` (and ``.gvcf``) to the VCF parser and everything
+            else to the headerless-TSV loader; ``.bcf`` raises a clear error.
+
+    Returns:
+        DataFrame with columns ``chr, pos, ref, alt, variant_id``.
+    """
+    if fmt == "vcf":
+        return load_variants_vcf(path)
+    if fmt == "tsv":
+        return io_utils.load_variants(path)
+    if fmt != "auto":
+        raise ValueError(f"Unknown format {fmt!r}; expected one of auto, tsv, vcf.")
+
+    # auto-detect by extension (strip any gzip suffix first)
+    base = path
+    if base.endswith(_GZIP_SUFFIXES):
+        base = base.rsplit(".", 1)[0]
+    if base.endswith(".bcf") or path.endswith(".bcf"):
+        raise ValueError(
+            f"Binary BCF is not supported ({path}); convert to VCF first, e.g. "
+            "`bcftools view in.bcf -Oz -o out.vcf.gz`."
+        )
+    if base.endswith(_VCF_SUFFIXES):
+        return load_variants_vcf(path)
+    return io_utils.load_variants(path)
+
+
+########
+# MAIN #
+########
+
+
+def main():
+    args = _parse_args()
+    df = read_variants(args.variants_loc, args.format)
+    # Write the full 5-col canonical table (variant_id included) so the converter
+    # output faithfully carries any VCF IDs forward.
+    df.to_csv(args.out_path, sep="\t", index=False, header=False)
+    logger.info("Wrote %d variant rows to %s", len(df), args.out_path)
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description="Convert a VCF/gVCF into the canonical headerless variant TSV "
+        "(chr, pos, ref, alt, variant_id)."
+    )
+    parser.add_argument(
+        "-v", "--variants_loc", required=True,
+        help="Input variants file (.vcf, .vcf.gz, or canonical TSV).",
+    )
+    parser.add_argument(
+        "-o", "--out_path", required=True,
+        help="Location to save the canonical headerless variant TSV.",
+    )
+    parser.add_argument(
+        "-f", "--format", default="auto", choices=["auto", "tsv", "vcf"],
+        help="Input format (default: auto, detected by extension).",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()
+
+
+"""
+python -m varscore.preprocessing.vcf -v input.vcf.gz -o variants.tsv
+"""


### PR DESCRIPTION
## What

Adds **VCF/gVCF** as an alternative input format to the canonical headerless TSV (`chr, pos, ref, alt[, variant_id]`). Every variant caller (GATK, DeepVariant, bcftools) emits VCF/gVCF, so requiring a hand-made TSV was an adoption barrier for the productionized library/container.

## Approach

The entire downstream pipeline (validate → region_filter → scorers → prioritization) consumes the canonical 5-col table, so VCF support is purely an **entry-point adapter**: parse VCF/gVCF → canonical DataFrame, and nothing downstream changes.

- **New `varscore/preprocessing/vcf.py`** — pure-Python parser, **no new dependency** (stdlib `gzip` reads `.vcf` and bgzipped `.vcf.gz`). Exposes `load_variants_vcf()`, a `read_variants(path, fmt="auto")` dispatch seam (extensible to more formats later), and a thin converter CLI.
- **Multi-allelic split** → one canonical row per ALT. **Symbolic / non-variant alleles dropped** (`<NON_REF>`, `<*>`, `<DEL>`, `*`, breakends, `ref==alt`) with a logged count — these dominate gVCF reference blocks and would otherwise explode into millions of rows. No binary `.bcf` (clear "convert with bcftools" error).
- **Wired into `validate.py` and `pipeline.py`** via a `-f/--format` flag (`auto`/`tsv`/`vcf`); the single `load_variants` call site becomes `read_variants(...)`. Chr normalization and ACGT/genome checks are deliberately left to the existing downstream `core/io.validate_variant`, not duplicated.
- **Custom variant IDs:** the VCF `ID` is captured into `variant_id` now. Full end-to-end ID threading stays gated on the existing `variant_id` drop in `validate.py`, which is left intact and documented as a contained follow-up — the new input path is built to be extensible to it.

## Usage

```bash
# standalone conversion
python -m varscore.preprocessing.vcf -v input.vcf.gz -o variants.tsv

# straight into the pipeline
python -m varscore.preprocessing.pipeline -i input.vcf.gz -f auto -g genome.fa \
    -o valid.tsv --invalid-out invalid.tsv --region-out-dir regions/
```

## Tests / docs

- New `tests/test_vcf.py` (12 cases: multiallelic, gVCF symbolic, `.vcf.gz` ≡ plaintext, dispatch incl. `.bcf` rejection, symbolic-only → empty-with-schema, malformed line). `vcf` added to the core import smoke test and the CI clean-install assertion.
- New `docs/vcf.md`; `CLAUDE.md` conventions + module map updated.
- No `pyproject.toml` change (zero new dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)