### PR TITLE
Preserve custom variant_id end-to-end

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,12 @@ contract; a model scorer like `scoring/chrombpnet/` swaps the parquet lookup for
 ## Conventions
 
 - **Variant files:** headerless TSV, columns `chr, pos, ref, alt[, variant_id]`
-  (`core.io.VARIANT_SCHEMA`). Scoring outputs append columns to these.
+  (`core.io.VARIANT_SCHEMA`). Scoring outputs append columns to these. The
+  optional `variant_id` (a TSV 5th column or a VCF `ID`) is **preserved
+  end-to-end** — every module reads columns by *name*, never by position, so a
+  custom id rides through validate → region_filter → scorers → prioritization (and
+  `annotate.py`) without stripping/reattaching. Blank when none is supplied; no
+  synthetic id is generated. See `docs/variant_id.md`.
 - **VCF/gVCF input** is accepted at the entry point via
   `core.io.read_variants(path, fmt="auto")` — the format-neutral loader that
   dispatches to `load_variants` (TSV) / `load_variants_vcf` (VCF). It's wired into
@@ -67,8 +72,8 @@ contract; a model scorer like `scoring/chrombpnet/` swaps the parquet lookup for
   table above so everything downstream is unchanged. Pure-Python (stdlib `gzip`,
   **no new dep**, reads `.vcf`/`.vcf.gz`); splits multi-allelic sites and drops
   symbolic alleles (`<NON_REF>`, `<*>`, `*`, breakends). No `.bcf`. The VCF `ID` is
-  captured into `variant_id`, but full end-to-end ID preservation is still gated on
-  the `variant_id` drop in `validate.py` — see `docs/vcf.md`.
+  captured into `variant_id` and preserved end-to-end — see `docs/vcf.md` and
+  `docs/variant_id.md`.
 - **Chromosome naming:** datasets use UCSC-style `chr1` / `chrM`; lookups
   normalize bare `1` / `MT` to the `chr` form. Caveat: a bare-chr value that
   slips past normalization classifies silently as `intergenic` — no error.

--- a/docs/variant_id.md
+++ b/docs/variant_id.md
@@ -1,0 +1,45 @@
+# Custom Variant IDs
+
+The canonical variant table's optional 5th column — `variant_id`
+(`core.io.VARIANT_SCHEMA`) — lets you attach a stable identifier to each variant
+and have it travel through **every** stage (preprocessing, region routing,
+scoring, prioritization, annotation), so outputs can be joined back to your input.
+
+## Where the id comes from
+
+- **TSV input:** the 5th column.
+- **VCF/gVCF input:** the `ID` field (`.` → blank). See [vcf.md](vcf.md).
+- **No id supplied:** the 5th column is left **blank** — no synthetic id is
+  generated. (Provide your own ids if you need a guaranteed unique handle, e.g.
+  for prioritization grouping; otherwise variants stay distinct by
+  `chr/pos/ref/alt`.)
+
+## How it flows
+
+- `core.io.load_variants` / `read_variants` always yield the 5-col schema
+  (`variant_id` is `NaN` when absent).
+- `preprocessing/validate.py` writes the **full** canonical schema for valid
+  variants — the id is no longer dropped on the valid path. Invalid variants keep
+  the id too, alongside the error columns.
+- `preprocessing/region_filter.py` routes whole rows, so the id rides into each
+  per-region-category file.
+- **Scorers carry it through by name, not position** — so a 5th column never
+  needs stripping/reattaching and never breaks anything:
+  - ChromBPNet ([score.py](../varscore/scoring/chrombpnet/score.py)) reads
+    `chr/pos/ref/alt` by name, appends score columns, and writes the whole frame.
+    The model only ever sees one-hot arrays, never the DataFrame.
+  - Fold-averaging ([predictions.py](../varscore/scoring/chrombpnet/predictions.py))
+    copies `VARIANT_SCHEMA` columns (incl. `variant_id`) from fold 0.
+  - AlphaMissense ([lookup.py](../varscore/scoring/alphamissense/lookup.py))
+    preserves all input columns and replicates the id across the per-transcript
+    row expansion.
+- `prioritization.py` uses `variant_id` as part of its pivot index key.
+- `annotation/annotate.py` carries `variant_id` onto each annotated JSONL record
+  (an optional field; `null` when absent).
+
+## Tests
+
+End-to-end preservation is covered by `tests/test_validate.py` (validate keeps the
+id, blank when absent), `tests/test_variant_region_filter.py` (routing preserves
+ids), `tests/test_scoring.py` + `tests/test_alphamissense_utils.py` (scorers carry
+ids, incl. multi-transcript replication), and `tests/test_annotate.py`.

--- a/docs/vcf.md
+++ b/docs/vcf.md
@@ -56,11 +56,8 @@ python -m varscore.preprocessing.pipeline -i input.vcf.gz -g genome.fa -f auto \
 - **Whole-file in memory.** Like the TSV loader, the parser returns one DataFrame;
   `validate` then batches at 250k. Fine for typical inputs.
 
-## Custom variant IDs (future work)
+## Custom variant IDs
 
-The VCF parser already captures the `ID` column into `variant_id`, and the
-standalone converter writes the full 5-column canonical TSV, so IDs survive the
-conversion. **End-to-end** ID preservation through the scorers is not yet wired:
-`preprocessing/validate.py` writes only `chr, pos, ref, alt` for valid variants
-(it drops `variant_id`). That single projection is the only blocker — the input
-path here is built to be extensible to it without further redesign.
+The VCF parser captures the `ID` column into `variant_id` (`.` → blank), and that
+id is preserved end-to-end through preprocessing, scoring, prioritization, and
+annotation. See [variant_id.md](variant_id.md).

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -1,0 +1,60 @@
+"""Tests that variant_id is threaded through the annotation utility.
+
+The data-backed lookups (region model, nearest genes, cCREs, allele freqs) are
+stubbed so annotation runs without the built artifacts — we only care that a
+custom variant_id flows from input to the annotated record.
+"""
+import json
+
+import pytest
+
+import varscore.annotation.maf as maf
+import varscore.annotation.regions as region_utils
+from varscore.annotation.annotate import (
+    AnnotatedVariant,
+    VariantAnnotationInput,
+    annotate_variant,
+    annotate_variants_file,
+)
+
+
+@pytest.fixture(autouse=True)
+def stub_annotation_sources(monkeypatch):
+    monkeypatch.setattr(
+        region_utils, "region_annotations",
+        lambda *a, **k: region_utils.RegionAnnotation(
+            labels=["intergenic"], gene_ids=[], primary="intergenic"
+        ),
+    )
+    monkeypatch.setattr(region_utils, "nearest_genes", lambda *a, **k: ([], False))
+    monkeypatch.setattr(region_utils, "ccre_overlap", lambda *a, **k: None)
+    monkeypatch.setattr(maf, "get_ot_variant", lambda *a, **k: None)
+
+
+def test_annotate_variant_carries_custom_id():
+    av = annotate_variant(
+        VariantAnnotationInput(
+            chr="chr1", pos=100, ref="A", alt="T", variant_id="rs_custom"
+        )
+    )
+    assert isinstance(av, AnnotatedVariant)
+    assert av.variant_id == "rs_custom"
+
+
+def test_annotate_variant_id_defaults_to_none():
+    av = annotate_variant(VariantAnnotationInput(chr="chr1", pos=100, ref="A", alt="T"))
+    assert av.variant_id is None
+
+
+def test_annotate_file_preserves_variant_id(tmp_path):
+    tsv = tmp_path / "variants.tsv"
+    # row 1 carries a custom id; row 2 has none (blank 5th field)
+    tsv.write_text("chr1\t100\tA\tT\trs_custom\nchr1\t200\tC\tG\t\n")
+    out = tmp_path / "annotated.jsonl"
+
+    annotate_variants_file(str(tsv), str(out))
+
+    records = [json.loads(line) for line in out.read_text().splitlines()]
+    assert len(records) == 2
+    assert records[0]["variant_id"] == "rs_custom"
+    assert records[1]["variant_id"] is None

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -31,6 +31,8 @@ def test_score_variant_df():
     assert "ips" in variant_df.columns
     assert len(variant_df.columns) == 9
     assert len(variant_df) == 5
+    # the custom variant_id rides through scoring untouched (name-based access)
+    assert list(variant_df["variant_id"]) == ["v1", "v2", "v3", "v4", "v5"]
 
 
 def test_compute_active_allele_quantile():

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -43,6 +43,33 @@ def variants_tsv(tmp_path):
     return str(p)
 
 
+@pytest.fixture
+def variants_tsv_4col(tmp_path):
+    # a genuine headerless 4-column file (no variant_id column at all)
+    r30, a30 = _ref_alt(30)
+    r40, a40 = _ref_alt(40)
+    p = tmp_path / "variants4.tsv"
+    p.write_text(f"chr1\t30\t{r30}\t{a30}\nchr1\t40\t{r40}\t{a40}\n")
+    return str(p)
+
+
+def test_validate_accepts_4col_tsv(genome, variants_tsv_4col, tmp_path):
+    """A 4-column TSV (no variant_id) is valid; output is canonical with a blank id."""
+    valid_out = tmp_path / "valid.tsv"
+    invalid_out = tmp_path / "invalid.tsv"
+
+    valid_df, invalid_df = validate_variants(
+        variants_tsv_4col, genome, str(valid_out), str(invalid_out), width=20
+    )
+
+    assert len(valid_df) == 2
+    assert invalid_df.empty
+
+    out = io_utils.load_variants(str(valid_out))
+    assert list(out.columns) == io_utils.VARIANT_SCHEMA
+    assert out["variant_id"].isna().all()  # no ids supplied -> all blank
+
+
 def test_validate_preserves_variant_id(genome, variants_tsv, tmp_path):
     valid_out = tmp_path / "valid.tsv"
     invalid_out = tmp_path / "invalid.tsv"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,64 @@
+"""Tests that preprocessing.validate preserves a custom variant_id end-to-end.
+
+A custom id (from a TSV 5th column or a VCF ID) must survive validation: the
+written valid-variants file is the canonical 5-col schema, carrying the id when
+present and a blank 5th field when absent.
+"""
+import pandas as pd
+import pytest
+
+import varscore.core.io as io_utils
+from varscore.preprocessing.validate import validate_variants
+
+# 60 bp reference; ref alleles are derived from it so they always match.
+_SEQ = "ACGT" * 15
+_OTHER = {"A": "C", "C": "A", "G": "T", "T": "G"}
+
+
+@pytest.fixture
+def genome(tmp_path):
+    p = tmp_path / "genome.fa"
+    p.write_text(f">chr1\n{_SEQ}\n")
+    return str(p)
+
+
+def _ref_alt(pos1):  # pos1 is 1-based
+    ref = _SEQ[pos1 - 1]
+    return ref, _OTHER[ref]
+
+
+@pytest.fixture
+def variants_tsv(tmp_path):
+    r30, a30 = _ref_alt(30)
+    r40, a40 = _ref_alt(40)
+    # row 1 carries a custom id; row 2 has none (blank 5th field)
+    df = pd.DataFrame(
+        [
+            ("chr1", 30, r30, a30, "rs_custom"),
+            ("chr1", 40, r40, a40, None),
+        ]
+    )
+    p = tmp_path / "variants.tsv"
+    df.to_csv(p, sep="\t", index=False, header=False)
+    return str(p)
+
+
+def test_validate_preserves_variant_id(genome, variants_tsv, tmp_path):
+    valid_out = tmp_path / "valid.tsv"
+    invalid_out = tmp_path / "invalid.tsv"
+
+    valid_df, invalid_df = validate_variants(
+        variants_tsv, genome, str(valid_out), str(invalid_out), width=20
+    )
+
+    # both variants are valid (refs were derived from the genome)
+    assert len(valid_df) == 2
+    assert invalid_df.empty
+
+    # the written valid file round-trips to the 5-col canonical schema
+    out = io_utils.load_variants(str(valid_out))
+    assert list(out.columns) == io_utils.VARIANT_SCHEMA
+
+    by_pos = {int(r["pos"]): r for _, r in out.iterrows()}
+    assert by_pos[30]["variant_id"] == "rs_custom"  # custom id preserved
+    assert pd.isna(by_pos[40]["variant_id"])  # absent id stays blank

--- a/varscore/annotation/annotate.py
+++ b/varscore/annotation/annotate.py
@@ -17,6 +17,7 @@ class VariantAnnotationInput(BaseModel):
     pos: int
     ref: str
     alt: str
+    variant_id: Optional[str] = None
 
 
 class AnnotatedVariant(BaseModel):
@@ -24,6 +25,7 @@ class AnnotatedVariant(BaseModel):
     pos: int
     ref: str
     alt: str
+    variant_id: Optional[str] = None
     ref_length: int
     alt_length: int
     variant_length: int
@@ -65,7 +67,9 @@ def annotate_variants_file(
     regardless of input size.
 
     Args:
-        variants_loc: Path to input TSV file (no header, columns: chr, pos, ref, alt)
+        variants_loc: Path to input TSV file (no header, columns: chr, pos, ref,
+            alt[, variant_id]). A 5th variant_id column, if present, is preserved
+            on each annotated record.
         out_path: Path to save annotated variants JSONL
         batch_size: Number of variants to process per batch
     """
@@ -81,10 +85,10 @@ def annotate_variants_file(
     total_written = 0
     start_time = time.time()
 
-    # Read input TSV in chunks
+    # Read input TSV in chunks (canonical schema; variant_id is optional)
     chunks = pd.read_csv(
         variants_loc, sep="\t", header=None,
-        names=["chr", "pos", "ref", "alt"],
+        names=["chr", "pos", "ref", "alt", "variant_id"],
         chunksize=batch_size,
     )
 
@@ -98,6 +102,7 @@ def annotate_variants_file(
                 pos=int(row["pos"]),
                 ref=row["ref"],
                 alt=row["alt"],
+                variant_id=None if pd.isna(row["variant_id"]) else str(row["variant_id"]),
             )
             for _, row in chunk_df.iterrows()
         ]
@@ -105,11 +110,17 @@ def annotate_variants_file(
         # Annotate batch
         annotated = annotate_variants(variants)
 
-        # Write batch to JSONL (append mode after the first batch)
+        # Write batch to JSONL (append mode after the first batch). We render to
+        # a string and append manually rather than passing mode= to to_json, which
+        # is only supported on pandas >= 2.0 (the project floor is 1.3.4).
         records = [av.model_dump() for av in annotated]
         batch_df = pd.DataFrame(records)
         write_mode = "w" if batch_num == 1 else "a"
-        batch_df.to_json(out_path, orient="records", lines=True, mode=write_mode)
+        json_lines = batch_df.to_json(orient="records", lines=True)
+        if not json_lines.endswith("\n"):
+            json_lines += "\n"
+        with open(out_path, write_mode) as f:
+            f.write(json_lines)
 
         total_written += len(records)
         batch_elapsed = time.time() - batch_start
@@ -168,6 +179,7 @@ def annotate_variant(variant: VariantAnnotationInput) -> AnnotatedVariant:
         pos=var_pos,
         ref=var_ref,
         alt=var_alt,
+        variant_id=variant.variant_id,
         ref_length=var_ref_length,
         alt_length=var_alt_length,
         variant_length=var_variant_length,
@@ -215,7 +227,7 @@ def _parse_args():
         description="Annotate variants with region type, nearest genes, cCREs, and allele frequencies."
     )
     parser.add_argument(
-        "-v", "--variants_loc", required=True, help="Input TSV file (no header, columns: chr, pos, ref, alt)"
+        "-v", "--variants_loc", required=True, help="Input TSV file (no header, columns: chr, pos, ref, alt[, variant_id])"
     )
     parser.add_argument(
         "-o", "--out_path", required=False, help="Output JSONL file with annotations"

--- a/varscore/preprocessing/validate.py
+++ b/varscore/preprocessing/validate.py
@@ -111,11 +111,12 @@ def validate_variants(
         invalid_variants.append(batch_invalid)
         
         # Write valid variants incrementally (append mode, no headers).
-        # NOTE: variant_id is intentionally dropped here for now. Preserving it
-        # end-to-end is a future goal; this projection is the single blocker to
-        # threading custom IDs through to the scorers (see docs/vcf.md).
+        # We write the full canonical schema so a custom variant_id (from a TSV
+        # 5th column or a VCF ID) is preserved end-to-end; downstream modules read
+        # by column name and carry it through. When no id was supplied the 5th
+        # field is simply blank (NaN -> empty). See docs/variant_id.md.
         if valid_out_path and not batch_valid.empty:
-            batch_valid[["chr", "pos", "ref", "alt"]].to_csv(
+            batch_valid[io_utils.VARIANT_SCHEMA].to_csv(
                 valid_out_path, sep="\t", index=False, header=False, mode="a"
             )
         


### PR DESCRIPTION
## What

Threads the canonical 5th column — `variant_id` (a TSV 5th field or a VCF `ID`) — through the **whole** pipeline so a custom id always comes back out attached to the results. Previously it was dropped at validation.

## Key finding: the scorers were never the blocker

A thorough read of every variant-consuming module showed they all access columns **by name, not position**, so a 5th column already rode through them untouched:

- **ChromBPNet** [score.py](../varscore/scoring/chrombpnet/score.py): loads 5 cols, `get_variant_seqs_with_genome` reads `row["chr"]`/`row["pos"]`, writes the whole frame back. The model only ever sees one-hot arrays — a DataFrame column can't reach TensorFlow.
- **Fold-averaging** [predictions.py:127](../varscore/scoring/chrombpnet/predictions.py#L127): explicitly carries `VARIANT_SCHEMA` columns (incl. `variant_id`) from fold 0.
- **AlphaMissense** [lookup.py](../varscore/scoring/alphamissense/lookup.py): `SELECT v.* EXCLUDE (_chr, _row)` preserves all input cols and replicates the id across multi-transcript row expansion.
- **prioritization** [prioritization.py:7](../varscore/prioritization.py#L7): already uses `variant_id` as a pivot key.

So **no strip/reattach is needed**. The only actual drop was [validate.py](../varscore/preprocessing/validate.py) projecting valid rows to `[chr,pos,ref,alt]`.

## Changes

- **validate.py**: write the full canonical schema (`io_utils.VARIANT_SCHEMA`) for valid variants. A provided id is preserved; when none is supplied the 5th field is left **blank** (no synthetic id — per design choice).
- **annotate.py** (side JSONL utility): added an optional `variant_id` field to `VariantAnnotationInput`/`AnnotatedVariant`, read the 5th column, carry it onto each record. Also fixes a latent bug — `to_json(mode=...)` requires pandas ≥2.0 but the project floor is `1.3.4`; now renders to a string and appends manually.
- **No change needed** to the scorers, region_filter, or prioritization — they already preserve it.

## Behavior when no id is given

The 5th column is left blank (NaN → empty). No synthetic `chr:pos:ref:alt` id is generated; variants stay distinct downstream by `chr/pos/ref/alt`.

## Tests

- New `tests/test_validate.py` — validate preserves a custom id and leaves it blank when absent (tiny in-memory genome fixture).
- New `tests/test_annotate.py` — id flows through `annotate_variant` and the file path (data lookups stubbed).
- Strengthened `tests/test_scoring.py` to assert id **values** survive scoring.
- region_filter routing and AlphaMissense per-transcript replication were already covered.

Full suite green (47 passed locally, excluding the pre-existing `duckdb`-not-installed tests in the dev venv).

## Docs

New `docs/variant_id.md`; `docs/vcf.md` and `CLAUDE.md` updated (the id story is no longer "future work").

🤖 Generated with [Claude Code](https://claude.com/claude-code)